### PR TITLE
feat: 리뷰어 매칭 시 자기자신이 매치 되지 않도록 수정

### DIFF
--- a/src/main/java/greedy/greedybot/application/matching/MatchingService.java
+++ b/src/main/java/greedy/greedybot/application/matching/MatchingService.java
@@ -1,9 +1,11 @@
 package greedy.greedybot.application.matching;
 
 import greedy.greedybot.application.matching.dto.MatchingResult;
-import java.util.HashMap;
+import greedy.greedybot.common.exception.GreedyBotException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 
@@ -17,70 +19,85 @@ public class MatchingService {
     }
 
     public MatchingResult matchStudy(final List<String> reviewees, final List<String> reviewers) {
-
         shuffleStrategy.shuffle(reviewers);
-
-        if (reviewees.size() >= reviewers.size()) {
-            return matchWhenRevieweesAreMore(reviewees, reviewers);
-        }
-
-        return matchWhenRevieweesAreFewer(reviewees, reviewers);
+        shuffleStrategy.shuffle(reviewees);
+        final List<String> alignedReviewer = alignReviewerByRevieweeSize(reviewees.size(), reviewers);
+        return match(reviewees, alignedReviewer);
     }
 
-    // 리뷰이가 리뷰어보다 적을때 랜덤 매칭
-    // 리뷰이 사람 수 만큼 리뷰어를 랜덤 선택하여 매칭 결과 생성
-    private MatchingResult matchWhenRevieweesAreFewer(final List<String> reviewees,
-                                                      final List<String> randomReviewers) {
-        // { 리뷰어1 : [리뷰이1] } 형태로 매칭 결과 표현
-        final Map<String, List<String>> matchingResult = new HashMap<>();
+    private List<String> alignReviewerByRevieweeSize(final int revieweeSize, final List<String> shuffledReviewers) {
+        if (revieweeSize > shuffledReviewers.size()) {
+            return alignWhenReviewersAreLess(revieweeSize, shuffledReviewers);
+        }
 
-        int index = 0;
+        if (revieweeSize < shuffledReviewers.size()) {
+            return alignWhenReviewersAreMore(revieweeSize, shuffledReviewers);
+        }
+
+        return shuffledReviewers;
+    }
+
+    // 리뷰어가 부족할 때, 리뷰어를 리뷰이 수 만큼 추가 선택
+    // ex) 리뷰이 6명, 리뷰어 4명 -> 리뷰어 4명 + 리뷰어 2명 추가 선택 |
+    //     리뷰어: [a, b, c, d] -> [a, b, c, d, a, b]
+    private List<String> alignWhenReviewersAreLess(final int revieweeSize, final List<String> shuffledReviewers) {
+        final int additionalReviewerCount = revieweeSize - shuffledReviewers.size();
+        final List<String> result = new ArrayList<>(shuffledReviewers);
+        for (int i = 0; i < additionalReviewerCount; i++) {
+            result.add(shuffledReviewers.get(i));
+        }
+        return result;
+    }
+
+    // 리뷰어가 더 많을 때, 리뷰이 사람 수 만큼 리뷰어 선택
+    // ex) 리뷰이 4명, 리뷰어 6명 -> 리뷰어 4명만 선택
+    //     리뷰어: [a, b, c, d, e, f] -> [a, b, c, d]
+    private List<String> alignWhenReviewersAreMore(final int revieweeSize, final List<String> shuffledReviewers) {
+        return shuffledReviewers.subList(0, revieweeSize);
+    }
+
+    private MatchingResult match(final List<String> reviewees, final List<String> reviewers) {
+        if (!validateNumberOfCases(reviewees, reviewers)) {
+            throw new GreedyBotException("매칭 경우의 수가 존재 하지 않습니다");
+        }
+
+        final Map<String, List<String>> matchedReviewers = reviewers.stream()
+                .collect(Collectors.toMap(
+                        key -> key,
+                        value -> new ArrayList<>(),
+                        (existing, replacement) -> existing
+                ));
+
+        final List<String> removableReviewees = new ArrayList<>(reviewees);
+        for (final String reviewer : reviewers) {
+            int cursor = 0;
+            while (!removableReviewees.isEmpty()) {
+                final String reviewee = removableReviewees.get(cursor);
+                if (reviewer.equals(reviewee)) {
+                    cursor++;
+                    continue;
+                }
+                matchedReviewers.get(reviewer).add(reviewee);
+                removableReviewees.remove(reviewee);
+                break;
+            }
+        }
+        return new MatchingResult(matchedReviewers);
+    }
+
+    // 이름이 같은 리뷰어-리뷰이 매칭이 불가능한 로직을 준수하는 경우의 수 검증
+    // ex) 리뷰어: [a, a, c] 리뷰이: [a, a, d] -> 매칭 불가능
+    private boolean validateNumberOfCases(final List<String> reviewees, final List<String> reviewers) {
+        final Map<String, Long> countByReviewerName = reviewers.stream()
+                .collect(Collectors.groupingBy(it -> it, Collectors.counting()));
+
         for (final String reviewee : reviewees) {
-            // 리뷰어에게 할당되는 리뷰이
-            final List<String> singleAssignedReviewee = List.of(reviewee);
-
-            matchingResult.put(randomReviewers.get(index++), singleAssignedReviewee);
+            long nonSameNameCount = reviewers.size() - countByReviewerName.getOrDefault(reviewee, 0L);
+            if (nonSameNameCount <= 0) {
+                return false;
+            }
         }
 
-        return new MatchingResult(matchingResult);
-    }
-
-    // 리뷰이가 리뷰어보다 많을때 랜덤 매칭
-    // 리뷰어가 같은 숫자로 리뷰이를 나눠 가진 다음 남은 리뷰이를 랜덤으로 한명씩 갖는 함수
-    private MatchingResult matchWhenRevieweesAreMore(final List<String> reviewees, final List<String> randomReviewers) {
-        // { 리뷰어1: [리뷰이1, 리뷰이2] } 형태로 매칭 결과 표현
-        final Map<String, List<String>> matchingResult = new HashMap<>();
-
-        final int revieweeSize = reviewees.size();
-        final int reviewerSize = randomReviewers.size();
-
-        // 공평하게 나눠 가질 리뷰이 숫자를 나타내는 변수
-        final int baseCount = revieweeSize / reviewerSize;
-        // 공평하게 나눠 갖고 남은 리뷰이 숫자를 나타내는 변수
-        int remainderCount = revieweeSize % reviewerSize;
-
-        int index = 0;
-
-        for (final String reviewer : randomReviewers) {
-            // 리뷰어에게 몇명의 리뷰이를 할당할지 나타내는 변수
-            final int assignCount = getAssignCount(baseCount, remainderCount);
-            remainderCount--;
-
-            // 리뷰어에게 할당되는 리뷰이들을 나타내는 변수
-            final List<String> assignedReviewees = reviewees.subList(index, index + assignCount);
-            index += assignCount;
-
-            matchingResult.put(reviewer, assignedReviewees);
-        }
-        return new MatchingResult(matchingResult);
-    }
-
-    // 남은 리뷰이 숫자가 존재한다면 리뷰어에게 한명의 리뷰이를 더 배정하는 함수
-    private int getAssignCount(final int baseCount, final int remainderCount) {
-        if (remainderCount > 0) {
-            return baseCount + 1;
-        }
-
-        return baseCount;
+        return true;
     }
 }

--- a/src/main/java/greedy/greedybot/application/matching/dto/MatchingResult.java
+++ b/src/main/java/greedy/greedybot/application/matching/dto/MatchingResult.java
@@ -4,18 +4,18 @@ import java.util.List;
 import java.util.Map;
 
 public class MatchingResult {
-    private final Map<String, List<String>> result;
+    private final Map<String, List<String>> revieweesByReviewer;
 
-    public MatchingResult(Map<String, List<String>> result) {
-        this.result = result;
+    public MatchingResult(Map<String, List<String>> revieweesByReviewer) {
+        this.revieweesByReviewer = revieweesByReviewer;
     }
 
     public String toDiscordAnnouncement() {
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("[리뷰이]  --  [리뷰어]\n");
 
-        for (final String reviewer : result.keySet()) {
-            final List<String> reviewees = result.get(reviewer);
+        for (final String reviewer : revieweesByReviewer.keySet()) {
+            final List<String> reviewees = revieweesByReviewer.get(reviewer);
             reviewees.forEach(reviewee -> stringBuilder.append(reviewee)
                     .append("    ->   ")
                     .append(reviewer)

--- a/src/main/java/greedy/greedybot/presentation/jda/listener/ReviewMatchListener.java
+++ b/src/main/java/greedy/greedybot/presentation/jda/listener/ReviewMatchListener.java
@@ -30,7 +30,7 @@ public class ReviewMatchListener implements AutoCompleteInteractionListener {
             "FE-2기: 강동현, 신지훈, 신지우, 박찬빈, 임규영, 정창우"
     );
     private static final List<String> reviewers = List.of(
-            "BE-2기: 원태연, 백경환, 송은우, 조승현, 정다빈",
+            "BE-2기: 원태연, 백경환, 송은우, 조승현, 정다빈, 신동훈",
             "FE-2기: 김범수, 김의천, 송혜정, 김민석"
     );
 

--- a/src/main/java/greedy/greedybot/presentation/jda/listener/SlashCommandListenerMapper.java
+++ b/src/main/java/greedy/greedybot/presentation/jda/listener/SlashCommandListenerMapper.java
@@ -43,7 +43,7 @@ public class SlashCommandListenerMapper extends ListenerAdapter {
             slashCommand.onAction(event);
         } catch (GreedyBotException e) {
             log.warn("[WARN]: {}", e.getMessage());
-            event.getHook().sendMessage("❌" + e.getMessage()).queue();
+            event.reply("❌" + e.getMessage()).setEphemeral(true).queue();
         } catch (Exception e) {
             log.error("[ERROR OCCURRED]: {}, {}", commandName, e.getStackTrace());
             event.getHook().sendMessage(e.getMessage()).queue();

--- a/src/test/java/greedy/greedybot/application/matching/MatchingServiceTest.java
+++ b/src/test/java/greedy/greedybot/application/matching/MatchingServiceTest.java
@@ -1,17 +1,15 @@
 package greedy.greedybot.application.matching;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import greedy.greedybot.application.matching.dto.MatchingResult;
 import greedy.greedybot.common.exception.GreedyBotException;
-import org.assertj.core.api.Assertions;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MatchingServiceTest {
     private MatchingService matchingService;
@@ -25,7 +23,7 @@ public class MatchingServiceTest {
     @DisplayName("리뷰어보다 리뷰이가 많을때 매칭 테스트")
     void testMatchStudyMoreReviewees() {
         //given
-        final List<String> reviewees = List.of("리뷰이1", "리뷰이2", "리뷰이3", "리뷰이4") ;
+        final List<String> reviewees = List.of("리뷰이1", "리뷰이2", "리뷰이3", "리뷰이4");
         final List<String> reviewers = List.of("리뷰어1", "리뷰어2");
 
         //when
@@ -43,7 +41,7 @@ public class MatchingServiceTest {
     @DisplayName("리뷰이보다 리뷰어가 많을때 매칭 테스트")
     void testMatchStudyMoreReviewers() {
         //given
-        final List<String> reviewees = List.of("리뷰이1", "리뷰이2") ;
+        final List<String> reviewees = List.of("리뷰이1", "리뷰이2");
         final List<String> reviewers = List.of("리뷰어1", "리뷰어2", "리뷰어3", "리뷰어4");
 
         //when
@@ -59,7 +57,7 @@ public class MatchingServiceTest {
     @DisplayName("리뷰어와 리뷰이가 같을때 매칭 테스트")
     void testMatchStudyDoesNotMatchSamePerson() {
         //given
-        final List<String> reviewees = List.of("태연", "해윤") ;
+        final List<String> reviewees = List.of("태연", "해윤");
         final List<String> reviewers = List.of("태연", "해윤");
 
         //when

--- a/src/test/java/greedy/greedybot/application/matching/MatchingServiceTest.java
+++ b/src/test/java/greedy/greedybot/application/matching/MatchingServiceTest.java
@@ -1,13 +1,17 @@
 package greedy.greedybot.application.matching;
 
 import greedy.greedybot.application.matching.dto.MatchingResult;
+import greedy.greedybot.common.exception.GreedyBotException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MatchingServiceTest {
     private MatchingService matchingService;
@@ -30,8 +34,8 @@ public class MatchingServiceTest {
         //then
         final String announcement = matchingResult.toDiscordAnnouncement();
         assertThat(announcement).contains("리뷰이1    ->   리뷰어1");
-        assertThat(announcement).contains("리뷰이2    ->   리뷰어1");
-        assertThat(announcement).contains("리뷰이3    ->   리뷰어2");
+        assertThat(announcement).contains("리뷰이2    ->   리뷰어2");
+        assertThat(announcement).contains("리뷰이3    ->   리뷰어1");
         assertThat(announcement).contains("리뷰이4    ->   리뷰어2");
     }
 
@@ -50,4 +54,34 @@ public class MatchingServiceTest {
         assertThat(announcement).contains("리뷰이1    ->   리뷰어1");
         assertThat(announcement).contains("리뷰이2    ->   리뷰어2");
     }
+
+    @RepeatedTest(20)
+    @DisplayName("리뷰어와 리뷰이가 같을때 매칭 테스트")
+    void testMatchStudyDoesNotMatchSamePerson() {
+        //given
+        final List<String> reviewees = List.of("태연", "해윤") ;
+        final List<String> reviewers = List.of("태연", "해윤");
+
+        //when
+        final MatchingResult matchingResult = matchingService.matchStudy(reviewees, reviewers);
+
+        //then
+        final String announcement = matchingResult.toDiscordAnnouncement();
+        assertThat(announcement).doesNotContain("태연    ->   태연");
+        assertThat(announcement).doesNotContain("해윤    ->   해윤");
+    }
+
+    @Test
+    @DisplayName("경우의 수가 존재하지 않을때 매칭 테스트")
+    void testMatchStudyDoesNotMatchNoCases() {
+        //given
+        final List<String> reviewees = List.of("태연", "승준");
+        final List<String> reviewers = List.of("태연", "태연"); // 동일한 이름의 리뷰이-리뷰어 매칭이 무조건 발생
+
+        //when & then
+        assertThatThrownBy(() -> matchingService.matchStudy(reviewees, reviewers))
+                .isInstanceOf(GreedyBotException.class)
+                .hasMessageContaining("매칭 경우의 수가 존재 하지 않습니다");
+    }
+
 }


### PR DESCRIPTION
## 작업 내용
- 동일한 이름의 리뷰이-리뷰어가 매칭 되지 않도록 수정 하였습니다.
- 위 규칙을 준수하는 경우의 수가 없는 입력값에 대한 검증을 추가 하였습니다.

## 참고 사항
- 기존 랜덤 매칭 로직을 분리하였습니다.

`AS-IS`
[랜덤 매칭 로직] + [리뷰어-리뷰이 수 조정]이 합쳐져 있었음.

`TO-BE`
[리뷰어-리뷰이 수 조정] 후 [랜덤 매칭 로직]이 이루어 지도록 분리.


## 관련 이슈
- closes #27 

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
- [x] PR 내부의 예시는 삭제하셨나요?
