### PR TITLE
fix: docker pull 실패 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,4 +83,4 @@ jobs:
             cd
             cd ${{ secrets.DISCORD_APP_PATH }} && cd ./bin
             echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-            sudo sh deploy.sh
+            sh deploy.sh


### PR DESCRIPTION
## 작업 내용
- build 터지는 문제 해결

`docker pull greedydeerg/greedy-bot:0.0.1` 명령어 실행 시 -> 성공

`sudo docker pull greedydeerg/greedy-bot:0.0.1` 명령어 실행 시 -> 실패
Error response from daemon: pull access denied for greedydeerg/greedy-bot, repository does not exist or may require 'docker login': denied: requested access to the resource is denied

docker login은 ubuntu로 하고, deploy.sh를 sudo로 실행(root사용자일 때 가능)해서 
root가 docker pull을 하니까 인증X -> 실패 한 것으로 추정

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
- [x] PR 내부의 예시는 삭제하셨나요?
