### PR TITLE
refactor: 4기 리뷰어 리뷰이 이름 수정

### DIFF
--- a/src/main/java/greedy/greedybot/presentation/jda/listener/matching/ReviewMatchListener.java
+++ b/src/main/java/greedy/greedybot/presentation/jda/listener/matching/ReviewMatchListener.java
@@ -33,12 +33,15 @@ public class ReviewMatchListener implements AutoCompleteInteractionListener, InC
 
     private static final Logger log = LoggerFactory.getLogger(ReviewMatchListener.class);
     private static final List<String> reviewees = List.of(
-        "BE-3기: 이고은, 김하늘, 하수한, 강동현, 서현진, 김태우",
-        "FE-3기: 강건, 심혁, 윤재홍, 강예령"
+        "BE-4기: 이태규, 김민욱, 이채현, 정명준, 김하은, 강대현",
+        "FE-4기: 천동현, 김동건, 홍의민, 고규민"
     );
     private static final List<String> reviewers = List.of(
-        "BE-3기: 백경환, 정다빈, 남해윤, 김준수, 신혜빈, 정상희, 조승현",
-        "FE-3기: 김민석, 정수영, 김의천, 최혜령"
+        "BE-4기(Java): 정다빈, 조상준, 이진, 이창희, 남해윤, 하수한",
+        "BE-4기(Spring): 정다빈, 조상준, 이진, 김민기, 김수민, 신혜빈",
+        "FE-4기(1차): 정창우, 김의천, 임규영, 송혜정",
+        "FE-4기(2차): 김범수, 김의천, 임규영, 송혜정",
+        "FE-4기(3차): 박찬빈, 김의천, 임규영, 송혜정"
     );
     private static final String REMATCH_BUTTON_ID = "rematch";
     private static final String CONFIRM_BUTTON_ID = "matching-confirm";


### PR DESCRIPTION
## 작업 내용
4기 리뷰어, 리뷰이 이름을 수정했습니다.

 나중에 커멘드로 리뷰어 리뷰이 수정할 수 있는 기능이 생기면 편할 것 같아요!

### BE
BE-4기(Java): 정다빈, 조상준, 이진, 이창희, 남해윤, 하수한
BE-4기(Spring): 정다빈, 조상준, 이진, 김민기, 김수민, 신혜빈

### FE
FE-4기(1차): 정창우, 김의천, 임규영, 송혜정
FE-4기(2차): 김범수, 김의천, 임규영, 송혜정
FE-4기(3차): 박찬빈, 김의천, 임규영, 송혜정


## 관련 이슈
- #46 

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
- [x] PR 내부의 예시는 삭제하셨나요?
