### PR TITLE
fix: 리뷰어 리뷰이 타입 검증 로직 수정

### DIFF
--- a/src/main/java/greedy/greedybot/presentation/jda/listener/matching/ReviewMatchListener.java
+++ b/src/main/java/greedy/greedybot/presentation/jda/listener/matching/ReviewMatchListener.java
@@ -191,7 +191,7 @@ public class ReviewMatchListener implements AutoCompleteInteractionListener, InC
     }
 
     private void validateReviewerAndRevieweeType(final String revieweeType, final String reviewerType) {
-        if (!revieweeType.equals(reviewerType)) {
+        if (!reviewerType.contains(revieweeType)) {
             log.warn("[REVIEWER AND REVIEWEE STUDY TYPE DISMATCH]");
             throw new GreedyBotException("\uD83D\uDEAB 리뷰어 리뷰이 스터디 타입 정보가 일치 하지 않습니다.");
         }


### PR DESCRIPTION
- 일치하는지 -> 포함하는지

## 작업 내용
### 3기까지의 선택 옵션
리뷰이 string: `"BE-3기: 이고은, 김하늘, 하수한, 강동현, 서현진, 김태우"`
리뷰어 string: `"BE-3기: 백경환, 정다빈, 남해윤, 김준수, 신혜빈, 정상희, 조승현"`

두 문자열을 `:`기준으로 파싱해 파싱 앞부분(BE-3기, BE-3기)가 equal 한 지 여부로 리뷰어 리뷰이 스터디 타입 일치 여부를 판단했습니다

### 현재의 선택 옵션 
리뷰이 string: `"BE-4기: 이태규, 김민욱, 이채현, 정명준, 김하은, 강대현"`
리뷰어 string: `"BE-4기(Java): 정다빈, 조상준, 이진, 이창희, 남해윤, 하수한"`

따라서 : 기준으로 파싱하면 각각 `BE-4기`와 `BE-4기(Java)`가 되기에 equal이 아닌 contains 함수를 쓰도록 수정했습니다

## PR 체크리스트
- [ ] 테스트는 모두 통과했나요?
- [ ] 빌드는 성공했나요?
- [ ] 코드 포맷팅을 진행했나요?
- [ ] PR 내부의 예시는 삭제하셨나요?
