### PR TITLE
feat: 스룸 예약 사이트 반환 기능 추가

### DIFF
--- a/src/main/java/greedy/greedybot/presentation/jda/listener/studyroom/StudyRoomListener.java
+++ b/src/main/java/greedy/greedybot/presentation/jda/listener/studyroom/StudyRoomListener.java
@@ -1,0 +1,44 @@
+package greedy.greedybot.presentation.jda.listener.studyroom;
+
+import greedy.greedybot.presentation.jda.listener.SlashCommandListener;
+import greedy.greedybot.presentation.jda.role.DiscordRole;
+import java.util.Set;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StudyRoomListener implements SlashCommandListener {
+
+    @Value("${study_room.site}")
+    private String studyRoomSiteUrl;
+
+    @Override
+    public String getCommandName() {
+        return "study-room";
+    }
+
+    @Override
+    public SlashCommandData getCommandData() {
+        return Commands.slash(this.getCommandName(), "버튼을 누르면 스터디룸 예약 자동화 사이트로 이동합니다.");
+    }
+
+    @Override
+    public void onAction(@NotNull final SlashCommandInteractionEvent event) {
+        event.reply(" ")
+            .addActionRow(
+                Button.link(studyRoomSiteUrl, "🚀 스터디룸 예약 바로가기")
+            )
+            .setEphemeral(true)
+            .queue();
+    }
+
+    @Override
+    public Set<DiscordRole> allowedRoles() {
+        return Set.of(DiscordRole.DEVELOPER, DiscordRole.LEAD);
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 작업 배경: 스터디 리드분들이 `스터디룸 자동예약 사이트`를 쓸 때마다 고정메시지 찾아야한다는 불편함이 있었습니다. 따라서 그리디 봇 명령어 입력 시 해당 사이트로 이어지도록 기능을 추가하였습니다.
- 작업 방식
  - 해당 명령어는 스터디 리드 + 디코봇 개발자 만 사용 가능합니다. 
  - 모든 채널에서 사용 가능합니다.
  - 명령어를 사용할 때, 사용한 뒤 모두 메시지가 남지 않아 아무 채널에서 자유롭게 사용할 수 있도록 하였습니다.
  - 커맨드 입력 시 나오는 버튼을 클릭하면 해당 사이트로 이동합니다.

추후 다른 사이트로의 확장도 고려하고있습니다!
리드분들의 수요에 맞게 작업 예정입니다.

## 참고 사항
해당 기능에대한 [wiki](https://www.notion.so/sejong-greedy/Wiki-333b889a1dd78088ab0eed7f5f00ea62?source=copy_link)를 작성해두었습니다.

## 관련 이슈
- #49 

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
- [x] PR 내부의 예시는 삭제하셨나요?
