### PR TITLE
feat: 예약메시지 채널 옵션에 메인테이너 채널 추가

### DIFF
--- a/src/main/java/greedy/greedybot/presentation/jda/listener/message/ScheduledMessageCommandListener.java
+++ b/src/main/java/greedy/greedybot/presentation/jda/listener/message/ScheduledMessageCommandListener.java
@@ -28,6 +28,7 @@ public class ScheduledMessageCommandListener implements SlashCommandListener {
         "🍃백엔드-스터디", ScheduledMessageChannel.BACKEND,
         "\uD83E\uDD8B프론트엔드-스터디", ScheduledMessageChannel.FRONT,
         "\uD83E\uDEE7리드-대화", ScheduledMessageChannel.LEAD_CONVERSATION,
+        "\uD83C\uDF594기-메인테이너-대화", ScheduledMessageChannel.MAINTAINER_4,
         "tf-discord-test-ground", ScheduledMessageChannel.TEST
     );
 

--- a/src/main/java/greedy/greedybot/presentation/jda/role/ScheduledMessageChannel.java
+++ b/src/main/java/greedy/greedybot/presentation/jda/role/ScheduledMessageChannel.java
@@ -5,5 +5,6 @@ public enum ScheduledMessageChannel {
     BACKEND,
     FRONT,
     LEAD_CONVERSATION,
+    MAINTAINER_4,
     TEST
 }

--- a/src/main/java/greedy/greedybot/presentation/jda/role/ScheduledMessageChannels.java
+++ b/src/main/java/greedy/greedybot/presentation/jda/role/ScheduledMessageChannels.java
@@ -15,6 +15,7 @@ public class ScheduledMessageChannels {
             ScheduledMessageChannel.NOTICE, scheduledMessageChannelProperty.greedyNoticeId(),
             ScheduledMessageChannel.BACKEND, scheduledMessageChannelProperty.greedyBackendStudy(),
             ScheduledMessageChannel.FRONT, scheduledMessageChannelProperty.greedyFrontendStudy(),
+            ScheduledMessageChannel.MAINTAINER_4, scheduledMessageChannelProperty.maintainer4(),
             ScheduledMessageChannel.TEST, scheduledMessageChannelProperty.tfDiscordTestGroud()
         );
     }

--- a/src/main/java/greedy/greedybot/presentation/jda/role/property/ScheduledMessageChannelProperty.java
+++ b/src/main/java/greedy/greedybot/presentation/jda/role/property/ScheduledMessageChannelProperty.java
@@ -8,6 +8,7 @@ public record ScheduledMessageChannelProperty(
         long greedyBackendStudy,
         long greedyFrontendStudy,
         long leadLeadConversation,
+        long maintainer4,
         long tfDiscordTestGroud
 ) {
 }


### PR DESCRIPTION
## 작업 내용
- 예약메시지를 보낼 수 있는 채널 옵션에 메인테이너 채널을 추가했습니다.

## 참고 사항
- 범수님

## 관련 이슈
- 범수님

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
- [x] PR 내부의 예시는 삭제하셨나요?
